### PR TITLE
Include integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/
+*.DS_Store

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,34 +1,47 @@
 pipeline {
+   options { disableConcurrentBuilds() }
    agent { label 'dss-plugin-tests'}
    environment {
-        HOST = "$dss_target_host"
+        PLUGIN_INTEGRATION_TEST_INSTANCE="$HOME/instance_config.json"
     }
    stages {
       stage('Run Unit Tests') {
          steps {
             sh 'echo "Running unit tests"'
+            catchError(stageResult: 'FAILURE') {
             sh """
                make unit-tests
                """
+            }
             sh 'echo "Done with unit tests"'
          }
       }
-//       stage('Run Integration Tests') {
-//          steps {
-//              withCredentials([string(credentialsId: 'dss-plugins-admin-api-key', variable: 'API_KEY')]) {
-//                 sh 'echo "Running integration tests"'
-//                 sh 'echo "$HOST"'
-//                 sh """
-//                    make integration-tests
-//                    """
-//                 sh 'echo "Done with integration tests"'
-//              }
-//          }
-//       }
-    }
+      stage('Run Integration Tests') {
+         steps {
+            sh 'echo "Running integration tests"'
+            catchError(stageResult: 'FAILURE') {
+            sh """
+               make integration-tests
+               """
+            }
+            sh 'echo "Done with integration tests"'
+         }
+      }
+   }
    post {
      always {
-        junit '*.xml'
+        script {
+           allure([
+                    includeProperties: false,
+                    jdk: '',
+                    properties: [],
+                    reportBuildPolicy: 'ALWAYS',
+                    results: [[path: 'tests/allure_report']]
+            ])
+
+            def status = currentBuild.currentResult
+            sh "file_name=\$(echo ${env.JOB_NAME} | tr '/' '-').status; touch \$file_name; echo \"${env.BUILD_URL};${env.CHANGE_TITLE};${env.CHANGE_AUTHOR};${env.CHANGE_URL};${env.BRANCH_NAME};${status};\" >> $HOME/daily-statuses/\$file_name"
+        }
      }
    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,34 @@
+pipeline {
+   agent { label 'dss-plugin-tests'}
+   environment {
+        HOST = "$dss_target_host"
+    }
+   stages {
+      stage('Run Unit Tests') {
+         steps {
+            sh 'echo "Running unit tests"'
+            sh """
+               make unit-tests
+               """
+            sh 'echo "Done with unit tests"'
+         }
+      }
+//       stage('Run Integration Tests') {
+//          steps {
+//              withCredentials([string(credentialsId: 'dss-plugins-admin-api-key', variable: 'API_KEY')]) {
+//                 sh 'echo "Running integration tests"'
+//                 sh 'echo "$HOST"'
+//                 sh """
+//                    make integration-tests
+//                    """
+//                 sh 'echo "Done with integration tests"'
+//              }
+//          }
+//       }
+    }
+   post {
+     always {
+        junit '*.xml'
+     }
+   }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,12 @@ pipeline {
    agent { label 'dss-plugin-tests'}
    environment {
         PLUGIN_INTEGRATION_TEST_INSTANCE="$HOME/instance_config.json"
+        UNIT_TEST_FILES_STATUS_CODE = sh(script: 'ls ./tests/*/unit/test*', returnStatus: true)
+        INTEGRATION_TEST_FILES_STATUS_CODE = sh(script: 'ls ./tests/*/integration/test*', returnStatus: true)
     }
    stages {
       stage('Run Unit Tests') {
+         when { environment name: 'UNIT_TEST_FILES_STATUS_CODE', value: "0"}
          steps {
             sh 'echo "Running unit tests"'
             catchError(stageResult: 'FAILURE') {
@@ -17,6 +20,7 @@ pipeline {
          }
       }
       stage('Run Integration Tests') {
+         when { environment name: 'INTEGRATION_TEST_FILES_STATUS_CODE', value: "0"}
          steps {
             sh 'echo "Running integration tests"'
             catchError(stageResult: 'FAILURE') {

--- a/Makefile
+++ b/Makefile
@@ -18,35 +18,34 @@ plugin:
 	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
 
 unit-tests:
-	@echo "[START] Running unit tests..."
+	@echo "Running unit tests..."
 	@( \
 		PYTHON_VERSION=`python3 -V 2>&1 | sed 's/[^0-9]*//g' | cut -c 1,2`; \
 		PYTHON_VERSION_IS_CORRECT=`cat code-env/python/desc.json | python3 -c "import sys, json; print(str($$PYTHON_VERSION) in [x[-2:] for x in json.load(sys.stdin)['acceptedPythonInterpreters']]);"`; \
-		if [ ! $$PYTHON_VERSION_IS_CORRECT ]; then echo "Python version $$PYTHON_VERSION is not in acceptedPythonInterpreters"; exit 1; fi; \
+		if [ $$PYTHON_VERSION_IS_CORRECT == "False" ]; then echo "Python version $$PYTHON_VERSION is not in acceptedPythonInterpreters"; exit 1; else echo "Python version $$PYTHON_VERSION is in acceptedPythonInterpreters"; fi; \
 	)
-	@( \
-		python3- -m venv env/; \
-		source env/bin/activate; \
-		pip3 install --upgrade pip; \
-		pip install --no-cache-dir -r tests/python/requirements.txt; \
-		pip install --no-cache-dir -r code-env/python/spec/requirements.txt; \
-		export PYTHONPATH="$(PYTHONPATH):$(PWD)/python-lib"; \
-		pytest -o junit_family=xunit2 --junitxml=unit.xml tests/python/unit || true; \
-		deactivate; \
-	)
-	@echo "[SUCCESS] Running unit tests: Done!"
-
-integration-tests:
-	@echo "[START] Running integration tests..."
 	@( \
 		rm -rf ./env/; \
-		python -m venv env/; \
+		python3 -m venv env/; \
 		source env/bin/activate; \
-		pip install --upgrade pip;\
+		pip3 install --upgrade pip;\
+		pip install --no-cache-dir -r tests/python/unit/requirements.txt; \
+		pip install --no-cache-dir -r code-env/python/spec/requirements.txt; \
+		export PYTHONPATH="$(PYTHONPATH):$(PWD)/python-lib"; \
+        pytest tests/python/unit --alluredir=tests/allure_report || ret=$$?; deactivate; exit $$ret \
+
+	)
+
+integration-tests:
+	@echo "Running integration tests..."
+	@( \
+		rm -rf ./env/; \
+		python3 -m venv env/; \
+		source env/bin/activate; \
+		pip3 install --upgrade pip;\
 		pip install --no-cache-dir -r tests/python/integration/requirements.txt; \
         pytest tests/python/integration --alluredir=tests/allure_report || ret=$$?; deactivate; exit $$ret \
 	)
-	@echo "[SUCCESS] Running integration tests: Done!"
 
 tests: unit-tests integration-tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL:=/bin/bash
+
 # Makefile variables set automatically
 plugin_id=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
 plugin_version=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`
@@ -7,45 +9,46 @@ last_commit_id=`git rev-parse HEAD`
 
 
 plugin:
-	@echo "[START] Archiving plugin to dist/ folder..."
+	@echo "Archiving plugin to dist/ folder..."
 	@cat plugin.json | json_pp > /dev/null
 	@rm -rf dist
 	@mkdir dist
 	@echo "{\"remote_url\":\"${remote_url}\",\"last_commit_id\":\"${last_commit_id}\"}" > release_info.json
 	@git archive -v -9 --format zip -o dist/${archive_file_name} HEAD
+	@zip --delete dist/${archive_file_name} "tests/*"
 	@zip -u dist/${archive_file_name} release_info.json
 	@rm release_info.json
-	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
+	@echo "Archiving plugin to dist/ folder: Done!"
 
+
+.ONESHELL:
 unit-tests:
+	@set -e
 	@echo "Running unit tests..."
-	@( \
-		PYTHON_VERSION=`python3 -V 2>&1 | sed 's/[^0-9]*//g' | cut -c 1,2`; \
-		PYTHON_VERSION_IS_CORRECT=`cat code-env/python/desc.json | python3 -c "import sys, json; print(str($$PYTHON_VERSION) in [x[-2:] for x in json.load(sys.stdin)['acceptedPythonInterpreters']]);"`; \
-		if [ $$PYTHON_VERSION_IS_CORRECT == "False" ]; then echo "Python version $$PYTHON_VERSION is not in acceptedPythonInterpreters"; exit 1; else echo "Python version $$PYTHON_VERSION is in acceptedPythonInterpreters"; fi; \
-	)
-	@( \
-		rm -rf ./env/; \
-		python3 -m venv env/; \
-		source env/bin/activate; \
-		pip3 install --upgrade pip;\
-		pip install --no-cache-dir -r tests/python/unit/requirements.txt; \
-		pip install --no-cache-dir -r code-env/python/spec/requirements.txt; \
-		export PYTHONPATH="$(PYTHONPATH):$(PWD)/python-lib"; \
-        pytest tests/python/unit --alluredir=tests/allure_report || ret=$$?; deactivate; exit $$ret \
+	@PYTHON_VERSION=`python3 -V 2>&1 | sed 's/[^0-9]*//g' | cut -c 1,2`
+	@PYTHON_VERSION_IS_CORRECT=`cat code-env/python/desc.json | python3 -c "import sys, json; print(str($$PYTHON_VERSION) in [x[-2:] for x in json.load(sys.stdin)['acceptedPythonInterpreters']]);"`
+	@if [ $$PYTHON_VERSION_IS_CORRECT == "False" ]; then echo "Python version $$PYTHON_VERSION is not in acceptedPythonInterpreters"; exit 1; else echo "Python version $$PYTHON_VERSION is in acceptedPythonInterpreters"; fi
+	@rm -rf ./env/
+	@python3 -m venv env/
+	@source env/bin/activate
+	@pip install --upgrade pip
+	@pip install --no-cache-dir -r tests/python/unit/requirements.txt
+	@pip install --no-cache-dir -r code-env/python/spec/requirements.txt
+	@export PYTHONPATH="$(PYTHONPATH):$(PWD)/python-lib"
+	@pytest tests/python/unit --alluredir=tests/allure_report
+	@echo "Running unit tests: Done!"
 
-	)
-
+.ONESHELL:
 integration-tests:
+	@set -e
 	@echo "Running integration tests..."
-	@( \
-		rm -rf ./env/; \
-		python3 -m venv env/; \
-		source env/bin/activate; \
-		pip3 install --upgrade pip;\
-		pip install --no-cache-dir -r tests/python/integration/requirements.txt; \
-        pytest tests/python/integration --alluredir=tests/allure_report || ret=$$?; deactivate; exit $$ret \
-	)
+	@rm -rf ./env/
+	@python3 -m venv env/
+	@source env/bin/activate
+	@pip install --upgrade pip
+	@pip install --no-cache-dir -r tests/python/integration/requirements.txt
+	@pytest tests/python/integration --alluredir=tests/allure_report
+	@echo "Running integration tests: Done!"
 
 tests: unit-tests integration-tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,54 @@
-PLUGIN_ID=sentiment-analysis
-PLUGIN_VERSION=1.4.0
+# Makefile variables set automatically
+plugin_id=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
+plugin_version=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`
+archive_file_name="dss-plugin-${plugin_id}-${plugin_version}.zip"
+remote_url=`git config --get remote.origin.url`
+last_commit_id=`git rev-parse HEAD`
 
-all:
-	cat plugin.json|json_pp > /dev/null
+
+plugin:
+	@echo "[START] Archiving plugin to dist/ folder..."
+	@cat plugin.json | json_pp > /dev/null
+	@rm -rf dist
+	@mkdir dist
+	@echo "{\"remote_url\":\"${remote_url}\",\"last_commit_id\":\"${last_commit_id}\"}" > release_info.json
+	@git archive -v -9 --format zip -o dist/${archive_file_name} HEAD
+	@zip -u dist/${archive_file_name} release_info.json
+	@rm release_info.json
+	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
+
+unit-tests:
+	@echo "[START] Running unit tests..."
+	@( \
+		PYTHON_VERSION=`python3 -V 2>&1 | sed 's/[^0-9]*//g' | cut -c 1,2`; \
+		PYTHON_VERSION_IS_CORRECT=`cat code-env/python/desc.json | python3 -c "import sys, json; print(str($$PYTHON_VERSION) in [x[-2:] for x in json.load(sys.stdin)['acceptedPythonInterpreters']]);"`; \
+		if [ ! $$PYTHON_VERSION_IS_CORRECT ]; then echo "Python version $$PYTHON_VERSION is not in acceptedPythonInterpreters"; exit 1; fi; \
+	)
+	@( \
+		python3- -m venv env/; \
+		source env/bin/activate; \
+		pip3 install --upgrade pip; \
+		pip install --no-cache-dir -r tests/python/requirements.txt; \
+		pip install --no-cache-dir -r code-env/python/spec/requirements.txt; \
+		export PYTHONPATH="$(PYTHONPATH):$(PWD)/python-lib"; \
+		pytest -o junit_family=xunit2 --junitxml=unit.xml tests/python/unit || true; \
+		deactivate; \
+	)
+	@echo "[SUCCESS] Running unit tests: Done!"
+
+integration-tests:
+	@echo "[START] Running integration tests..."
+	@( \
+		rm -rf ./env/; \
+		python -m venv env/; \
+		source env/bin/activate; \
+		pip install --upgrade pip;\
+		pip install --no-cache-dir -r tests/python/integration/requirements.txt; \
+        pytest tests/python/integration --alluredir=tests/allure_report || ret=$$?; deactivate; exit $$ret \
+	)
+	@echo "[SUCCESS] Running integration tests: Done!"
+
+tests: unit-tests integration-tests
+
+dist-clean:
 	rm -rf dist
-	mkdir dist
-	zip -r dist/dss-plugin-${PLUGIN_ID}-${PLUGIN_VERSION}.zip code-env custom-recipes python-lib resource plugin.json

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,6 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27"],
-  "forceConda": false,
-  "installCorePackages": true,
-  "installJupyterSupport": false
+	"acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37"],
+	"forceConda": false,
+	"installCorePackages": true,
+	"installJupyterSupport": false
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "sentiment-analysis",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "meta": {
         "label": "Sentiment Analysis",
         "category": "Natural Language Processing",

--- a/tests/python/integration/pytest.ini
+++ b/tests/python/integration/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+usefixtures = plugin dss_target

--- a/tests/python/integration/requirements.txt
+++ b/tests/python/integration/requirements.txt
@@ -1,0 +1,3 @@
+pytest==6.2.1
+dataiku-api-client
+git+git://github.com/dataiku/dataiku-plugin-tests-utils.git@master#egg=dataiku-plugin-tests-utils

--- a/tests/python/integration/test_scenario.py
+++ b/tests/python/integration/test_scenario.py
@@ -4,25 +4,20 @@ project_key = "PLUGINTESTSENTIMENTANALYSIS"
 
 
 def test_binary_classification(user_dss_clients):
-    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="TESTBINARYCLASSIFICATION",
-                     user="user1")
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="TESTBINARYCLASSIFICATION")
 
 
 def test_5_points_scale_classification(user_dss_clients):
-    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="TEST5POINTSSCALECLASSIFICATION",
-                     user="default")
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="TEST5POINTSSCALECLASSIFICATION")
 
 
 def test_different_settings(user_dss_clients):
-    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_different_options",
-                     user="default")
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_different_options")
 
 
 def test_edge_cases(user_dss_clients):
-    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_edge_cases",
-                     user="default")
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_edge_cases")
 
 
 def test_partition_by_language(user_dss_clients):
-    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_partition_by_language",
-                     user="default")
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_partition_by_language")

--- a/tests/python/integration/test_scenario.py
+++ b/tests/python/integration/test_scenario.py
@@ -1,0 +1,28 @@
+from dku_plugin_test_utils import dss_scenario
+
+project_key = "PLUGINTESTSENTIMENTANALYSIS"
+
+
+def test_binary_classification(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="TESTBINARYCLASSIFICATION",
+                     user="user1")
+
+
+def test_5_points_scale_classification(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="TEST5POINTSSCALECLASSIFICATION",
+                     user="default")
+
+
+def test_different_settings(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_different_options",
+                     user="default")
+
+
+def test_edge_cases(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_edge_cases",
+                     user="default")
+
+
+def test_partition_by_language(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Test_partition_by_language",
+                     user="default")


### PR DESCRIPTION
Following the latest changes in of the `dss-plugin-tests` library, I added 5 integration tests to the sentiment analysis plugin. They run 5 scenarios which check : 
- binary classification 
- 5 points scale classification 
- different output settings
- edge cases
- partitions by different languages