### PR TITLE
Use absolute value of confidence versus relative to batch

### DIFF
--- a/custom-recipes/sentiment-analysis-score/recipe.py
+++ b/custom-recipes/sentiment-analysis-score/recipe.py
@@ -112,8 +112,9 @@ with output_dataset.get_writer() as writer:
                     else ""
                     for p in predicted_scores
                 ]
-        if output_probabilities:
-            df[new_cols[2]] = np.array(confidence_list) / float(max(confidence_list))
+        if output_probabilities: 
+            # df[new_cols[2]] = np.array(confidence_list) / float(max(confidence_list)) 
+            df[new_cols[2]] = np.array(confidence_list) / float(1.0000)
 
         # Append dataframe to output Dataset
         if chunk_idx == 0:


### PR DESCRIPTION
Outputting the probability of sentiment relative to the batch in which it was created renders confidence scores meaningless for comparison across datasets and for use in scoring. This interfered with a project I was working on for identifying Fake News as the model used the confidence + the sentiment value in helping identify Fake News.

Replace this with a 1 so that this can be used as an absolute and/or make a relative probability within the batch as well.

We could also call this out as relative confidence value and create a new absolute confidence value if there were concern about keeping consistent functionality. That said, at the least this needs to be called out in the dialog.