### PR TITLE
Added support for Python versions 3.7 - 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Version 1.6.0](https://github.com/dataiku/dss-plugin-nlp-sentiment-analysis/releases/tag/v1.6.0) - New feature - 2023-04
+- ✨ Added support for Python versions 3.7, 3.8, 3.9, 3.10, 3.11

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -2,9 +2,14 @@
 	"acceptedPythonInterpreters": [
 		"PYTHON27", 
 		"PYTHON36", 
-		"PYTHON37"
+		"PYTHON37",
+		"PYTHON38",
+		"PYTHON39",
+		"PYTHON310",
+		"PYTHON311"
 	],
 	"forceConda": false,
 	"installCorePackages": true,
+	"corePackagesSet": "AUTO",
 	"installJupyterSupport": false
 }

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,3 @@
-scipy==1.2.3
 pybind11==2.6.2
 fasttext==0.9.1
 six==1.15.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sentiment-analysis",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"meta": {
 		"label": "Sentiment Analysis",
 		"category": "Natural Language Processing",


### PR DESCRIPTION
[sc-132149]

Added Python 3.7, 3.8, 3.9, 3.10, 3.11

Removed `scipy` from the `requirements.txt` file, as the core packages contain the appropriate version of `scipy` for the Python version.

---

- Tested on staging using my own project and Python versions 2.7, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
    - Checked that each Python version gives exactly the same outputs
    - https://staging-design.qa.managedinstances.dkucloud-dev.com/projects/PLUGINTESTSENTIMENTANALYSIS/
- Tested on the example project on dku34 using Python 3.11
    - Ran every scenario, and checked that the outputs look reasonable
    - `ssh -L 15200:localhost:15200 anellis@dku34.dataiku.com`
    - http://localhost:15200/projects/PLUGINTESTSENTIMENTANALYSIS/flow/